### PR TITLE
fix: fixed typo in Hero Section Title

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -141,7 +141,7 @@ const Home = () => {
                Image Compression & Conversion Made Pixel Perfect.
               </h1>
               <p className="mt-5 text-4xl font-bold leading-tight text-gray-900 sm:leading-tight sm:text-5xl lg:text-5xl lg:leading-tight font-pj">
-                Compress image size upto 90% wihout
+                Compress image size upto 90% without
                 <span className="relative inline-flex sm:inline">
                   <span className="bg-gradient-to-r from-blue-500 to-blue-600 blur-lg filter opacity-30 w-full h-full absolute inset-0" />
                   <span className="relative"> losing much of pixels.</span>


### PR DESCRIPTION
Fixes #9

![image](https://github.com/user-attachments/assets/14987385-9b86-4fbe-bbcc-8c4d07a43d7f)