### PR TITLE
fix: The layout shift on drawer opening in mobile-view

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -24,7 +24,7 @@ const Home = () => {
       <div className="overflow-x-hidden bg-gray-50">
         <header className="py-4 md:py-6">
           <div className="container px-4 mx-auto sm:px-6 lg:px-8">
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between relative">
               <div className="flex-shrink-0 p-4 sm:p-0">
                 <Link
                   href="/"
@@ -97,7 +97,7 @@ const Home = () => {
                 </Link>
               </div>
             </div>
-            <nav className="hidden menu">
+            <nav className={`hidden menu w-screen absolute right-0 bg-white z-10 p-5  rounded-b-xl border-2`}>
               <div className="px-1 py-8">
                 <div className="grid gap-y-7">
                   <a


### PR DESCRIPTION
### Description

This PR addresses issue #24 where, when the drawer was opened in mobile view, the layout shifts unexpectedly, leading to a disruptive experience for users.

### Changes Made
_Page layout Before the drawer is opened:_
<img width="476" alt="BEFORE" src="https://github.com/user-attachments/assets/65659b35-3b16-4c46-8594-18eee3e6b4ae">

_Notice that the heading shifts down after the drawer is opened_
<img width="391" alt="AFTER1" src="https://github.com/user-attachments/assets/2c8e9c57-196a-4da6-8c6e-9f29c6f23f4b">

 _After the FIX the drawer overlaps rather than shifting the whole layout of the page and the page element retains it position_
<img width="338" alt="afterfix" src="https://github.com/user-attachments/assets/6812721a-3651-4c8d-bf8f-60f5cce73717">

### Related Issue
Fixes #24 