### PR TITLE
Added Dark Mode Toggle to Navbar

### DIFF
--- a/app/ThemeSwitcher.tsx
+++ b/app/ThemeSwitcher.tsx
@@ -1,0 +1,43 @@
+"use client";
+import {useTheme} from "next-themes";
+import {useEffect, useState} from "react";
+const ThemeSwitcher = () => {
+  const [mount, setMount] = useState(false);
+  const {systemTheme, theme, setTheme} = useTheme();
+  const currentTheme = theme === "system" ? systemTheme : theme;
+  useEffect(() => {
+    setMount(true);
+  }, []);
+  console.log(currentTheme);
+  return mount ? (
+    <div className="fixed right-5 z-[10000000000] max-lg:bottom-2.5 lg:top-1/3">
+      <button
+        onClick={() => setTheme(currentTheme === "dark" ? "light" : "dark")}
+        type="button"
+        className="flex h-10 w-10 p-2 items-center justify-center rounded-md border border-gray-800 text-gray-800 focus:outline-none focus:ring-0 focus:ring-gray-200 dark:border-slate-300 dark:text-white"
+      >
+        <svg
+          className="dark:hidden"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
+        </svg>
+        <svg
+          className="hidden dark:block"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+            fillRule="evenodd"
+            clipRule="evenodd"
+          ></path>
+        </svg>
+      </button>
+    </div>
+  ) : null;
+};
+export default ThemeSwitcher;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,6 @@ export const generateMetadata = (): Metadata => {
     ogImage: encodeURI(`https://picwise.co/api/og?title=Picwise`),
   });
 };
-const metadata = generateMetadata();
 
 
 export default function RootLayout({
@@ -21,30 +20,17 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-
   return (
     <ClerkProvider>
       <html lang="en">
-        <head>
-          <meta charSet="UTF-8" />
-          <meta name="theme-color" content="#ffffff" />
-          <meta name="application-name" content="Picwise" />
-          <meta name="description" content={metadata.description ?? ""} />
-          <link rel="canonical" href="https://picwise.co" />
+      
+        <body className={`${inter.className} dark:bg-medium`}>    
 
-          <meta property="og:url" content={metadata.openGraph?.url?.toString()} />
-          <meta property="og:site_name" content={metadata.openGraph?.siteName} />
-          <meta property="og:title" content={metadata.openGraph?.title?.toString()} />
-          <meta property="og:description" content={metadata.openGraph?.description} />
-          <meta property="og:locale" content={metadata.openGraph?.locale} />
-          
-          <meta name="twitter:title" content={metadata.twitter?.title as string} />
-          <meta name="twitter:description" content={metadata.twitter?.description} />
-          <meta name="twitter:creator" content={metadata.twitter?.creator} />
-        </head>
-        <body className={inter.className}>
+        
           {children}
+      
         </body>
+        
       </html>
     </ClerkProvider>
   );

--- a/components/AIPage.tsx
+++ b/components/AIPage.tsx
@@ -5,9 +5,8 @@ import aiIllustration from '../public/assets/Saly-13.png'
 const AIPage = () => {
   return (
     <>
-    <div className="mt-32 sm:mt-12 p-6">
+    <div className="mt-32 sm:mt-12 p-5">
         
-
 
     </div>
     </>

--- a/components/ContributeCTA.tsx
+++ b/components/ContributeCTA.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image'
 const ContributeCTA = () => {
   return (
     <>
-<div className="bg-white" id='contribute'>
+<div className="bg-white dark:bg-medium" id='contribute'>
   <div className="mx-auto max-w-7xl py-24 sm:px-6 sm:py-32 lg:px-8">
     <div className="relative isolate overflow-hidden bg-gray-900 px-6 pt-16 shadow-2xl sm:rounded-3xl sm:px-16 md:pt-24 lg:flex lg:gap-x-20 lg:px-24 lg:pt-0">
       <svg viewBox="0 0 1024 1024" className="absolute left-1/2 top-1/2 -z-10 h-[64rem] w-[64rem] -translate-y-1/2 [mask-image:radial-gradient(closest-side,white,transparent)] sm:left-full sm:-ml-80 lg:left-1/2 lg:ml-0 lg:-translate-x-1/2 lg:translate-y-0" aria-hidden="true">
@@ -17,7 +17,7 @@ const ContributeCTA = () => {
           </radialGradient>
         </defs>
       </svg>
-      <div className="mx-auto max-w-md text-center lg:mx-0 lg:flex-auto lg:py-32 lg:text-left">
+      <div className="mx-auto max-w-md text-center lg:mx-0 lg:flex-auto lg:py-32 lg:text-left ">
         <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">PicWise is<br />Open Source.</h2>
         <p className="mt-6 text-lg leading-8 text-gray-300">We are Open Source Innovators, feel free to contribute to official GitHub repo of picwise and help us improve our platform.</p>
         <div className="mt-10 flex items-center justify-center gap-x-6 lg:justify-start">

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -19,11 +19,11 @@ const Dashboard: React.FC<props> = ({ children }) => {
   const pathname = usePathname();
   return (
     <>
-      <div>
-        <nav className="fixed top-0 z-50 w-full bg-white border-b border-gray-200  ">
+      <div className="">
+        <nav className="fixed top-0 z-50 w-full bg-white border-b border-gray-200  dark:bg-dark">
           <div className="px-3 py-3 lg:px-5 lg:pl-3">
             <div className="flex items-center justify-between">
-              <div className="flex items-center justify-start rtl:justify-end">
+              <div className="flex items-center justify-start rtl:justify-end ">
                 <button
                   data-drawer-target="logo-sidebar"
                   data-drawer-toggle="logo-sidebar"
@@ -74,20 +74,20 @@ const Dashboard: React.FC<props> = ({ children }) => {
         </nav>
         <aside
           id="logo-sidebar"
-          className="fixed top-0 left-0 z-40 w-64 h-screen pt-20 transition-transform -translate-x-full bg-white border-r border-gray-200 sm:translate-x-0  "
+          className="fixed top-0 dark:bg-medium left-0 z-40 w-64 h-screen pt-20 transition-transform -translate-x-full bg-white border-r border-gray-200 sm:translate-x-0  "
           aria-label="Sidebar"
         >
-          <div className="h-full px-3 pb-4 overflow-y-auto bg-white ">
-            <ul className="space-y-2 font-medium">
+          <div className="h-full px-3 pb-4 overflow-y-auto bg-white dark:bg-medium">
+            <ul className="space-y-2 font-medium dark:bg-medium">
             <li>
                 <Link
                   href="/dashboard/compression"
                   className={`${
-                    pathname == "/dashboard/compression" && `bg-gray-200`
-                  } flex items-center p-2 text-gray-900 rounded-lg  hover:bg-gray-100  group`}
+                    pathname == "/dashboard/compression" && `bg-gray-200 dark:bg-gray-500`
+                  } flex items-center p-2 text-gray-900 rounded-lg  hover:bg-gray-100 dark:hover:bg-gray-500  group`}
                 >
-                  <Minimize2 size={25} />
-                  <span className="mx-3">
+                  <Minimize2 size={25} className="dark:text-white"/>
+                  <span className="mx-3 dark:text-white">
                     Compressor
                   </span>
                 </Link>
@@ -96,17 +96,17 @@ const Dashboard: React.FC<props> = ({ children }) => {
                 <Link
                   href="/dashboard/converter"
                   className={`${
-                    pathname == "/dashboard/converter" && `bg-gray-200`
-                  }  flex items-center p-2 text-gray-900 rounded-lg  hover:bg-gray-100  group`}
+                    pathname == "/dashboard/converter" && `bg-gray-200 dark:bg-gray-500`
+                  }  flex items-center p-2 text-gray-900 rounded-lg  hover:bg-gray-100 dark:hover:bg-gray-500  group`}
                 >
-                <LucideLayoutDashboard size={25} />
-                  <span className="mx-3">Converter</span>
+                <LucideLayoutDashboard size={25} className="dark:text-white" />
+                  <span className="mx-3 dark:text-white">Converter</span>
                 </Link>
               </li>
             </ul>
           </div>
         </aside>
-        <div className="p-4 sm:ml-64 bg-blue-50 dark:bg-blue-950 h-[100vh]">{children}</div>
+        <div className="p-4 sm:ml-64 bg-blue-50 dark:bg-blue-950 h-[100vh] ">{children}</div>
       </div>
     </>
   );

--- a/components/DropBox.tsx
+++ b/components/DropBox.tsx
@@ -74,7 +74,7 @@ const DropBox = () => {
 
       <main className="flex-1 bg-blue-50 dark:bg-blue-950 mt-12">
         <div className="container mx-auto py-8 px-6">
-          <div className="flex flex-col items-center justify-center gap-8">
+          <div className="flex flex-col items-center justify-center gap-8 ">
             <div className="flex w-full max-w-4xl flex-col items-center justify-center rounded-lg border border-blue-200 bg-white p-8 shadow-lg dark:border-blue-800 dark:bg-blue-900 ">
               <h1 className="text-3xl font-bold text-blue-950 dark:text-white">
                 Compress Your Images Better.

--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -6,43 +6,43 @@ import { DownloadIcon, FileEdit, LucideEdit3 } from 'lucide-react'
 const Features = () => {
   return (
     <>
-<div className="overflow-hidden bg-white py-24 sm:py-32" id='features'>
+<div className="overflow-hidden bg-white py-24 sm:py-32 dark:bg-medium" id='features'>
   <div className="mx-auto max-w-7xl px-6 lg:px-8">
     <div className="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-2">
       <div className="lg:px-8 lg:py-4">
-        <div className="lg:max-w-lg">
-          <h2 className="text-base font-semibold leading-7 text-indigo-600">90% Efficient</h2>
-          <p className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Effortless Image Compression & Conversion</p>
-          <p className="mt-6 text-lg leading-8 text-gray-600">
+        <div className="lg:max-w-lg ">
+          <h2 className="text-base font-semibold leading-7  text-indigo-600">90% Efficient</h2>
+          <p className="mt-2 text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl dark:text-white ">Effortless Image Compression & Conversion</p>
+          <p className="mt-6 text-lg leading-8 text-gray-600 dark:text-white">
             Compress and convert images with ease. Resize, Convert, and Compress images in just a few clicks. PicWise is designed to make image compression and conversion better than ever.
           </p>
           <dl className="mt-10 max-w-xl space-y-8 text-base leading-7 text-gray-600 lg:max-w-none">
-            <div className="relative pl-9">
-              <dt className="inline font-semibold text-gray-900">
-                <svg className="absolute left-1 top-1 h-5 w-5 text-indigo-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <div className="relative pl-9 ">
+              <dt className="inline font-semibold text-gray-900 dark:text-indigo-600">
+                <svg className="absolute left-1 top-1 h-5 w-5 text-indigo-600 " viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path fillRule="evenodd" d="M5.5 17a4.5 4.5 0 01-1.44-8.765 4.5 4.5 0 018.302-3.046 3.5 3.5 0 014.504 4.272A4 4 0 0115 17H5.5zm3.75-2.75a.75.75 0 001.5 0V9.66l1.95 2.1a.75.75 0 101.1-1.02l-3.25-3.5a.75.75 0 00-1.1 0l-3.25 3.5a.75.75 0 101.1 1.02l1.95-2.1v4.59z" clipRule="evenodd" />
                 </svg>
                 Upload Image
               </dt>
-              <dd className="inline"> Effortlessly upload images directly to our platform for instant compression or conversion.</dd>
+              <dd className="inline dark:text-white"> Effortlessly upload images directly to our platform for instant compression or conversion.</dd>
             </div>
           </dl>
           <dl className="mt-10 max-w-xl space-y-8 text-base leading-7 text-gray-600 lg:max-w-none">
             <div className="relative pl-9">
-              <dt className="inline font-semibold text-gray-900">
+              <dt className="inline font-semibold text-gray-900 dark:text-indigo-600">
                 <LucideEdit3 className="absolute left-1 top-1 h-5 w-5 text-indigo-600" />
                 Compress/Convert Image
               </dt>
-              <dd className="inline"> Compress or Converted images in just a few clicks.</dd>
+              <dd className="inline dark:text-white"> Compress or Converted images in just a few clicks.</dd>
             </div>
           </dl>
           <dl className="mt-10 max-w-xl space-y-8 text-base leading-7 text-gray-600 lg:max-w-none">
             <div className="relative pl-9">
-              <dt className="inline font-semibold text-gray-900">
-                <DownloadIcon className="absolute left-1 top-1 h-5 w-5 text-indigo-600" />
+              <dt className="inline font-semibold text-gray-900 dark:text-indigo-600">
+                <DownloadIcon className="absolute left-1 top-1 h-5 w-5 text-indigo-600 dark:text-indigo-600" />
                 Download Image
               </dt>
-              <dd className="inline"> Download image in seconds with just a click.</dd>
+              <dd className="inline dark:text-white"> Download image in seconds with just a click.</dd>
             </div>
           </dl>
         </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,44 +1,30 @@
 "use client";
-
-import { useState, useEffect } from "react";
-import Image from "next/image";
-import Link from "next/link";
+import { FiSun } from "react-icons/fi";
 import logo from "../public/assets/image.png";
+import { FaRegMoon } from "react-icons/fa";
 import picwisedahboardmobile from "../public/assets/picwise-dashboard-mobile.png";
 import picwisedahboard from "../public/assets/picwise-dashboard.png";
-import WatchDemoModal from "./WatchDemoModal";
+import {useTheme} from 'next-themes';
+import Image from "next/image";
+import { RiMoonLine, RiSunLine } from "react-icons/ri";
+import Link from "next/link";
+import { useState,useEffect } from "react";
+import ToogleTheme  from "./ToogleTheme";
 
 const Home = () => {
-  const [isModalOpen, setModalOpen] = useState(false);
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  
+  const {theme, setTheme } = useTheme();
 
-  const toggleMobileMenu = () => {
-    setIsMobileMenuOpen(!isMobileMenuOpen);
+
+  const showMobileNav = () => {
+    document.querySelector(".menu")?.classList.toggle("hidden");
   };
-
-  const openModal = () => setModalOpen(true);
-  const closeModal = () => setModalOpen(false);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth >= 1024) {
-        setIsMobileMenuOpen(false);
-      }
-    };
-
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
-  return (
+  return(
     <>
       <div className="overflow-x-hidden bg-gray-50">
-        <header className="py-4 md:py-6 relative z-50 bg-gray-50">
+        <header className="py-4 md:py-6 dark:bg-dark">
           <div className="container px-4 mx-auto sm:px-6 lg:px-8">
-            <div className="flex items-center justify-between relative">
+            <div className="flex items-center justify-between">
               <div className="flex-shrink-0 p-4 sm:p-0">
                 <Link
                   href="/"
@@ -48,52 +34,34 @@ const Home = () => {
                     src={logo}
                     width={35}
                     height={30}
-                    className="mx-1"
+                    className="mx-1 dark:text-white"
                     alt="picwise Logo"
                   />
                   Pic
                   <span className="text-blue-600">Wise</span>.
                 </Link>
               </div>
-
               <div className="flex lg:hidden">
                 <button
                   type="button"
-                  className="text-gray-900 z-50"
-                  onClick={toggleMobileMenu}
+                  className="text-gray-900"
+                  onClick={showMobileNav}
                 >
-                  <span aria-hidden="true">
-                    {isMobileMenuOpen ? (
-                      <svg
-                        className="w-7 h-7"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth="1.5"
-                          d="M6 18L18 6M6 6l12 12"
-                        />
-                      </svg>
-                    ) : (
-                      <svg
-                        className="w-7 h-7"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth="1.5"
-                          d="M4 6h16M4 12h16M4 18h16"
-                        />
-                      </svg>
-                    )}
+                  <span x-show="!expanded" aria-hidden="true">
+                    <svg
+                      className="w-7 h-7"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.5"
+                        d="M4 6h16M4 12h16M4 18h16"
+                      />
+                    </svg>
                   </span>
                 </button>
               </div>
@@ -101,37 +69,38 @@ const Home = () => {
               <div className="hidden lg:flex lg:ml-16 lg:items-center lg:justify-center lg:space-x-10 xl:space-x-16">
                 <a
                   href="#features"
-                  className="text-base font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2"
+                  className="text-base dark:text-white font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2"
                 >
                   Features
                 </a>
                 <a
                   href="#pricing"
-                  className="text-base font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2"
+                  className="text-base font-medium dark:text-white text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2"
                 >
                   Pricing
                 </a>
                 <a
                   href="#contribute"
-                  className="text-base font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2"
+                  className="text-base dark:text-white font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2"
                 >
                   Contribute
                 </a>
               </div>
-
               <div className="hidden lg:ml-auto lg:flex lg:items-center lg:space-x-10">
+              <div>
+                <ToogleTheme/>
+              </div>
                 <Link href="/dashboard/compression">
-                  <div
-                    className="inline-flex items-center justify-center px-6 py-3 text-base font-bold leading-7 text-white transition-all duration-200 bg-blue-600 border border-transparent rounded-xl hover:bg-blue-700 font-pj focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-900"
-                    role="button"
-                  >
-                    Dashboard
-                  </div>
+                    <div
+                      className="inline-flex items-center justify-center px-6 py-3 text-base font-bold leading-7 text-white transition-all duration-200 bg-blue-600 border border-transparent rounded-xl hover:bg-blue-700 font-pj focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-900 dark:text-white"
+                      role="button"
+                    >
+                      Dashboard
+                    </div>
                 </Link>
               </div>
             </div>
-
-            <nav className={`hidden menu w-screen absolute right-0 bg-white z-10 p-5  rounded-b-xl border-2`}>
+            <nav className="hidden menu ">
               <div className="px-1 py-8">
                 <div className="grid gap-y-7">
                   <a
@@ -177,64 +146,16 @@ const Home = () => {
           </div>
         </header>
 
-        <div
-          className={`lg:hidden fixed inset-0 z-40 bg-gray-50 transform ${
-            isMobileMenuOpen ? "translate-y-0" : "-translate-y-full"
-          } transition-transform duration-300 ease-in-out`}
-        >
-          <div className="flex flex-col h-full pt-20">
-            <div className="flex flex-col flex-grow justify-center items-center">
-              <a
-                href="#features"
-                className="text-2xl font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2 mb-8"
-                onClick={toggleMobileMenu}
-              >
-                Features
-              </a>
-              <a
-                href="#pricing"
-                className="text-2xl font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2 mb-8"
-                onClick={toggleMobileMenu}
-              >
-                Pricing
-              </a>
-              <a
-                href="#"
-                className="text-2xl font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2 mb-8"
-                onClick={toggleMobileMenu}
-              >
-                Automation
-              </a>
-              <a
-                href="#"
-                className="text-2xl font-medium text-gray-900 transition-all duration-200 rounded focus:outline-none font-pj hover:text-opacity-50 focus:ring-1 focus:ring-gray-900 focus:ring-offset-2 mb-8"
-                onClick={toggleMobileMenu}
-              >
-                {" "}
-                Customer Login{" "}
-              </a>
-              <Link href="/dashboard/compression">
-                <div
-                  className="inline-flex items-center justify-center px-6 py-3 text-base font-bold leading-7 text-white transition-all duration-200 bg-blue-600 border border-transparent rounded-xl hover:bg-blue-700 font-pj focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-900"
-                  role="button"
-                >
-                  Dashboard
-                </div>
-              </Link>
-            </div>
-          </div>
-        </div>
-
-        <section className="pt-12 bg-gray-50 sm:pt-16">
+        <section className="pt-12 bg-gray-50 sm:pt-16 dark:bg-medium ">
           <div className="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
-            <div className="max-w-2xl mx-auto text-center">
-              <h1 className="px-6 text-lg text-gray-600 font-inter">
-                Image Compression & Conversion Made Pixel Perfect.
+            <div className="max-w-2xl mx-auto text-center ">
+              <h1 className="px-6 text-lg text-gray-600 font-inter dark:text-white">
+               Image Compression & Conversion Made Pixel Perfect.
               </h1>
-              <p className="mt-5 text-4xl font-bold leading-tight text-gray-900 sm:leading-tight sm:text-5xl lg:text-5xl lg:leading-tight font-pj">
-                Compress image size upto 90% without
+              <p className="mt-5 text-4xl font-bold leading-tight text-gray-900 dark:text-white sm:leading-tight sm:text-5xl lg:text-5xl lg:leading-tight font-pj">
+                Compress image size upto 90% wihout
                 <span className="relative inline-flex sm:inline">
-                  <span className="bg-gradient-to-r from-blue-500 to-blue-600 blur-lg filter opacity-30 w-full h-full absolute inset-0" />
+                  <span className="bg-gradient-to-r from-blue-500 dark:text-white to-blue-600 blur-lg filter opacity-30 w-full h-full absolute inset-0" />
                   <span className="relative"> losing much of pixels.</span>
                 </span>
               </p>
@@ -246,9 +167,10 @@ const Home = () => {
                 >
                   Get Started
                 </Link>
-                <button
-                  onClick={openModal}
-                  className="inline-flex items-center justify-center w-full px-6 py-3 mt-4 text-lg font-bold text-gray-900 transition-all duration-200 border-2 border-gray-400 sm:w-auto sm:mt-0 rounded-xl font-pj focus:outline-none focus:ring-2 focus:ring-offset-2 hover:bg-gray-200 focus:bg-gray-200"
+                <a
+                  href="https://youtu.be/TJc3oEmVGHg?si=S5rZWD1sHAIp-QAP"
+                  target="_blank"
+                  className="inline-flex dark:text-white items-center justify-center w-full px-6 py-3 mt-4 text-lg font-bold text-gray-900 transition-all duration-200 border-2 border-gray-400 sm:w-auto sm:mt-0 rounded-xl font-pj focus:outline-none focus:ring-2 focus:ring-offset-2 hover:bg-gray-200 focus:bg-gray-200"
                   role="button"
                 >
                   <svg
@@ -267,27 +189,25 @@ const Home = () => {
                     />
                   </svg>
                   Watch the demo
-                </button>
+                </a>
               </div>
-              <p className="mt-8 text-base text-gray-500 font-inter">
+              <p className="mt-8 text-base text-gray-500 font-inter dark:text-white">
                 Free Image Compression & Conversion.
               </p>
             </div>
           </div>
-          <div className="pb-12">
+          <div className="pb-12  ">
             <div className="relative ">
-              <div className="absolute inset-0 h-2/3 bg-gray-50" />
+              <div className="absolute inset-0 h-2/3 bg-gray-50 dark:bg-medium" />
               <div className="relative mx-auto">
-                <div className="lg:max-w-6xl lg:mx-auto my-6">
-                <Image src={picwisedahboard} alt="picwise Dashboard" className="rounded-md hidden sm:block shadow-2xl shadow-blue-500/50" />
+                <div className="lg:max-w-6xl lg:mx-auto my-6 dark:bg-medium">
+                <Image src={picwisedahboard} alt="picwise Dashboard" className="rounded-md hidden sm:block shadow-2xl  shadow-blue-500/50" />
                 <Image src={picwisedahboardmobile} alt="picwise Mobile Dashboard" className="rounded-md block ml-4 sm:hidden shadow-2xl shadow-blue-500/50" />
                 </div>
               </div>
             </div>
           </div>
         </section>
-        {/* Watch Video Modal */}
-        <WatchDemoModal isOpen={isModalOpen} onClose={closeModal} />
       </div>
     </>
   );

--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -144,11 +144,11 @@ export default function Main() {
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
 
   return (
-    <div className="flex flex-col gap-4 mt-12 sm:mt-12 p-4 bg-blue-50 md:p-6">
+    <div className="flex flex-col gap-4 mt-12 sm:mt-12 p-4 bg-blue-50 md:p-6 ">
     <ToastContainer />
-    <main className="flex flex-col gap-4 sm:px-6 sm:py-0 md:gap-8">
+    <main className="flex flex-col gap-4 sm:px-6 sm:py-0 md:gap-8 dark:bg-medium">
       <div className="flex flex-col gap-4 md:grid md:grid-cols-1 lg:grid-cols-[1fr_300px]">
-        {/* Dropbox Section */}
+        
         <div className="flex flex-col items-center justify-center gap-8">
             <div className="flex w-full max-w-4xl flex-col items-center justify-center rounded-lg border border-blue-200 bg-white p-8 shadow-lg dark:border-blue-800 dark:bg-blue-900 ">
               <h1 className="text-3xl font-bold text-blue-950 dark:text-white">

--- a/components/Pricing.tsx
+++ b/components/Pricing.tsx
@@ -6,25 +6,25 @@ const Pricing = () => {
   <>
 <section className="flex items-center justify-center my-10 pb-10" id='pricing'>
   <div className="p-4 sm:px-10 flex flex-col justify-center items-center text-base h-100vh mx-auto" id="pricing">
-    <h3 className="text-5xl font-semibold text-center flex gap-2 justify-center mb-10">Pro Plan Coming Soon...</h3>
+    <h3 className="text-5xl font-semibold text-center flex gap-2 justify-center mb-10 dark:text-white">Pro Plan Coming Soon...</h3>
     <div className="isolate mx-auto grid max-w-md grid-cols-1 gap-8 lg:mx-0 lg:max-w-none lg:grid-cols-2">
       <div className="ring-1 ring-gray-200 rounded-3xl p-8 xl:p-10">
         <div className="flex items-center justify-between gap-x-4">
-          <h3 id="tier-standard" className="text-gray-900 text-2xl font-semibold leading-8">Free</h3>
+          <h3 id="tier-standard" className="text-gray-900 text-2xl font-semibold leading-8 dark:text-white">Free</h3>
         </div>
-        <p className="mt-4 text-base leading-6 text-gray-600">Use free plan for unlimited free image compressions</p>
+        <p className="mt-4 text-base leading-6 text-gray-600 dark:text-white">Use free plan for unlimited free image compressions</p>
         <p className="mt-6 flex items-baseline gap-x-1">
-       <span className="text-5xl font-bold tracking-tight text-gray-900">$0</span>
+       <span className="text-5xl font-bold tracking-tight text-gray-900 dark:text-white">$0</span>
         </p>
         <Link href={'/dashboard/compression'} aria-describedby="tier-standard" className="text-blue-600 ring-1 ring-inset ring-blue-200 hover:ring-blue-300 mt-6 block rounded-md py-2 px-3 text-center text-base font-medium leading-6 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">Continue with free</Link>
         <ul role="list" className="mt-8 space-y-3 text-sm leading-6 text-gray-600 xl:mt-10">
-          <li className="flex gap-x-3 text-base">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true" className="h-6 w-5 flex-none text-blue-600">
+          <li className="flex gap-x-3 text-base dark:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true" className="h-6 dark:text-white w-5 flex-none text-blue-600">
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>Lifetime access
           </li>
-          <li className="flex gap-x-3 text-base">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true" className="h-6 w-5 flex-none text-blue-600">
+          <li className="flex gap-x-3 text-base dark:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true" className="h-6 dark:text-white w-5 flex-none text-blue-600">
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>No AI features
           </li>
@@ -36,18 +36,18 @@ const Pricing = () => {
           <p className="rounded-full bg-blue-600/10 px-2.5 py-1 text-xs font-semibold leading-5 text-blue-600">
             Coming Soon</p>
         </div>
-        <p className="mt-4 text-base leading-6 text-gray-600">PicWise. AI</p>
+        <p className="mt-4 text-base leading-6 text-gray-600 dark:text-white">PicWise. AI</p>
         <p className="mt-6 flex items-baseline gap-x-1">
-          <span className="line-through text-2xl font-sans text-gray-500/70">$59</span><span className="text-5xl font-bold tracking-tight text-gray-900">$39</span>
+          <span className="line-through text-2xl font-sans text-gray-500/70 dark:text-white">$59</span><span className="text-5xl font-bold tracking-tight text-gray-900 dark:text-white">$39</span>
         </p>
         <Link href={'/dashboard/compression'} aria-describedby="tier-extended" className="bg-blue-600 text-white shadow-sm hover:bg-blue-500 mt-6 block rounded-md py-2 px-3 text-center text-base font-medium leading-6 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">Buy now</Link>
         <ul role="list" className="mt-8 space-y-3 text-sm leading-6 text-gray-600 xl:mt-10">
-          <li className="flex gap-x-3 text-base">
+          <li className="flex gap-x-3 text-base dark:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true" className="h-6 w-5 flex-none text-blue-600">
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>Lifetime access
           </li>
-          <li className="flex gap-x-3 text-base">
+          <li className="flex gap-x-3 text-base dark:text-white">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true" className="h-6 w-5 flex-none text-blue-600">
               <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>All AI features

--- a/components/ToogleTheme.tsx
+++ b/components/ToogleTheme.tsx
@@ -1,0 +1,42 @@
+"use client"
+import {useEffect , useState} from "react"
+import {FaMoon} from "react-icons/fa"
+import {BsSunFill} from "react-icons/bs"
+import React from 'react'
+
+
+const ToogleTheme = () => {
+    const [darkMode,setDarkMode]=useState(true);
+
+    useEffect(()=>{
+        const theme = localStorage.getItem("theme")
+        if (theme === "dark") setDarkMode(true)
+    },[])
+
+    useEffect(()=>{
+        if (darkMode){
+            document.documentElement.classList.add('dark')
+            localStorage.setItem("theme","dark")
+        }
+        else{
+            document.documentElement.classList.remove('dark')
+            localStorage.setItem("theme","light")
+        }
+    },[darkMode]);
+  return (
+    <>
+    <div className="relative w-16 h-8 flex item-center dark:bg-gray-900 bg-blue-600 cursor-pointer rounded-full p-1 "
+    onClick={()=>{setDarkMode(!darkMode)}}>
+        <FaMoon className="text-white " size={20}/>
+        <div className="absolute bg-white  w-6 h-6 rounded-full shadow-md transform transition-transform duration-300"
+        style={darkMode ?{left : "2px"}:{right: "2px"}}>
+
+        </div>
+        <BsSunFill className="ml-auto text-yellow-400"
+        size={20}/>
+    </div>
+    </>
+  )
+}
+
+export default ToogleTheme

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,13 +1,14 @@
 import type { Config } from "tailwindcss"
 
 const config = {
-  darkMode: ["class"],
+  
   content: [
     './pages/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
     './app/**/*.{ts,tsx}',
     './src/**/*.{ts,tsx}',
 	],
+  darkMode: 'class',
   prefix: "",
   theme: {
     container: {
@@ -22,6 +23,8 @@ const config = {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
+        dark:'#232A3C',
+        medium:'#293245',
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         primary: {
@@ -74,7 +77,10 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    require("tailwindcss-animate"),
+  ],
+  
 } satisfies Config
 
 export default config


### PR DESCRIPTION
## Issue Link:
Resolves #8 

## Changes Made:
- Implemented a dark mode toggle button in the navigation bar.
- Users can now switch between light and dark themes by clicking the button.
- The current theme is applied dynamically using state management, and relevant CSS classes are toggled accordingly.

## Implementation Details:
- Added a state variable to track the current theme (light or dark).
- Applied corresponding CSS for both light and dark modes.
- Used a button in the navigation bar to allow users to switch between the two modes.

## Screenshots:
- **Light Mode**:
![Light Mode Screenshot](https://github.com/user-attachments/assets/2a8d5226-a798-49be-a07b-ad46b9b47a98)
![image](https://github.com/user-attachments/assets/09fbe017-7de3-4953-bc8e-bbdd6223ae92)

  
- **Dark Mode**:
![Dark Mode Screenshot](https://github.com/user-attachments/assets/328e1abb-1d73-4406-a578-e4bd50beec8f)
![image](https://github.com/user-attachments/assets/c5d37dd7-e3fc-4021-8954-d7b8b36aa361)


## Labels:
I would greatly appreciate it if @Aryainguz could add the following labels, if appropriate:
- `hacktoberfest`
- `level ` ( any suitable level deemed appropriate)

Thank you for your consideration!

