### PR TITLE
#Add Code_Of_Conduct.md

### DIFF
--- a/Code_Of_Conduct.md
+++ b/Code_Of_Conduct.md
@@ -1,0 +1,94 @@
+# PicWise.co Project Code of Conduct
+
+## Welcome
+
+Welcome to the **PicWise.co** repository! **PicWise** is an innovative image optimization tool built on Next.js 14, designed to help users effortlessly enhance and compress images for optimal web performance and stunning visual impact. Our goal is to create an inclusive, collaborative, and respectful community where contributors can work together to build an exceptional image optimization tool for users worldwide.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the **PicWise.co** project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We are committed to contributing to an open, welcoming, diverse, inclusive, and healthy community where all participants feel respected and empowered.
+
+## Our Standards
+
+To maintain a positive, productive, and welcoming environment in the **PicWise.co** project, all participants are expected to uphold the following standards:
+
+### Positive Behavior:
+- **Respectful Communication**: Engage in respectful and constructive discussions that focus on advancing the project.
+- **Constructive Feedback**: Provide actionable feedback that is designed to help others improve, while maintaining a positive and supportive tone.
+- **Collaboration**: Work openly with others, sharing knowledge, ideas, and resources to enhance the platform and solve challenges.
+- **Inclusivity**: Use language and behavior that welcomes and includes all participants, regardless of their background or experience level.
+- **Recognition**: Acknowledge and appreciate the contributions of others, whether through code, design, or feedback.
+- **Professionalism**: Maintain professionalism in all interactions, ensuring that the project’s goals and values are prioritized.
+
+### Unacceptable Behavior:
+- **Harassment**: Harassment of any kind, including unwelcome comments, personal attacks, or inappropriate behavior, is strictly prohibited.
+- **Discrimination**: Discriminatory remarks or actions based on personal identity, beliefs, or background will not be tolerated.
+- **Disrespect**: Engaging in dismissive, inflammatory comments, trolling, or disruptive behavior that undermines the project’s collaborative environment is unacceptable.
+- **Privacy Violations**: Sharing private or sensitive information about others without their explicit consent is prohibited.
+- **Unethical Conduct**: Misusing the project’s resources, promoting false information, or violating ethical standards is not allowed.
+- **Disruption**: Any actions that intentionally disrupt or interfere with the project’s progress or the community’s collaboration will not be tolerated.
+
+## Project Goals
+
+The **PicWise.co** project aims to create a powerful image optimization tool that helps users enhance and compress images for improved web performance. The primary goals of the project include:
+
+- **Image Optimization**: Offering users a seamless experience for enhancing and compressing images, ensuring optimal performance without sacrificing visual quality.
+- **Web Performance**: Providing tools that help developers and designers optimize images for faster load times and better user experiences on the web.
+- **Innovation & Usability**: Building an intuitive platform using modern technologies like Next.js 14 to ensure a user-friendly interface and advanced optimization capabilities.
+- **Open Source Collaboration**: Encouraging developers, designers, and contributors to enhance the platform’s features through collaboration and knowledge sharing.
+
+## Enforcement Responsibilities
+
+Community leaders and maintainers of the **PicWise.co** project are responsible for enforcing this Code of Conduct. They are expected to:
+
+- Clearly communicate the standards for acceptable behavior and ensure that all participants are aware of them.
+- Address violations of the Code of Conduct in a timely, fair, and transparent manner.
+- Take appropriate corrective actions, such as removing inappropriate comments, posts, or contributions that violate community standards.
+- Apply disciplinary measures, including temporary or permanent bans, in cases of repeated or serious violations of the Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies to all spaces managed by the **PicWise.co** project, including GitHub repositories, issue trackers, discussions, and other communication platforms. It also applies when community members represent the project in public spaces, such as conferences, online events, or forums.
+
+## Reporting Violations
+
+If you experience or witness behavior that violates this Code of Conduct, please report it through the project’s communication channels (e.g., GitHub issues or discussions). All reports will be handled confidentially, and community leaders will take appropriate action to address the situation and prevent further violations.
+
+## Consequences of Unacceptable Behavior
+
+If a community member is found to have violated this Code of Conduct, the community leaders may take the following actions:
+
+1. **Correction**: A private conversation with the individual to address the violation and provide guidance on how to improve their behavior.
+2. **Warning**: A formal warning outlining the unacceptable behavior and providing expectations for future conduct.
+3. **Temporary Suspension**: A temporary suspension from participating in the project or community spaces, with the possibility of reinstatement after review.
+4. **Permanent Ban**: Permanent removal from the project and all community spaces for repeated or severe violations.
+
+## Enforcement Guidelines
+
+Community leaders will follow these guidelines when determining the consequences for violations of this Code of Conduct:
+
+1. **Correction**:
+   - **Community Impact**: A minor violation that causes minimal disruption to the project.
+   - **Consequence**: A private conversation to clarify the violation and provide guidance on behavior improvement.
+
+2. **Warning**:
+   - **Community Impact**: A moderate violation that negatively affects the collaborative environment of the project.
+   - **Consequence**: A formal warning with clear expectations for future behavior.
+
+3. **Temporary Suspension**:
+   - **Community Impact**: A significant violation that harms the community or disrupts the project’s progress.
+   - **Consequence**: Temporary suspension from participating in the project, with the possibility of reinstatement after review.
+
+4. **Permanent Ban**:
+   - **Community Impact**: A severe or repeated violation that undermines the project’s goals or the community’s values.
+   - **Consequence**: Permanent removal from the project and all related spaces.
+
+## Building a Positive Community
+
+At **PicWise.co**, we are dedicated to creating a welcoming, inclusive, and supportive community where developers, designers, and contributors can collaborate to build an exceptional image optimization tool. By working together, we can create a platform that empowers users to enhance their images and optimize their web performance. Let’s work together with respect, integrity, and a shared passion for building innovative solutions in web performance.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available [here](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).


### PR DESCRIPTION
closes #33 

This PR addresses the addition of code of conduct markdown file for the users of Picwise.co repository. 

Please add level1 and gssoc-ext labels to this PR.

Thank you!

